### PR TITLE
Build image on top of official and recent MediaWiki image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
-# Docker image that extends the base with email packages.
-FROM benhutchins/mediawiki:postgres
+# Docker image that extends the base with postgres and email packages.
+FROM mediawiki:stable
 MAINTAINER XSF Editors <editor@xmpp.org>
+RUN set -x; \
+		apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libpq-dev \
+    && docker-php-ext-install pgsql \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN pear channel-update pear.php.net && pear upgrade --force PEAR && pear install mail net_smtp


### PR DESCRIPTION
The previous image has not been updated in years, but the official
MediaWiki images do not include Postgres support.

Since the current XSF Wiki is running on Postgres and I have no desire
to migrate all that data, it seems simpler to simply add Postgres
support here.