### PR TITLE
README: Remove docker hub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Docker Build Status](https://img.shields.io/docker/build/xmppxsf/mediawiki.svg)](https://hub.docker.com/r/xmppxsf/mediawiki/)
-
 # mediawiki-docker
 
 This repository holds the Dockerfile that is used to run the container serving [wiki.xmpp.org](https://wiki.xmpp.org).


### PR DESCRIPTION
We don't use docker hub anymore